### PR TITLE
update egaugex parser logic to include all registers - fixes #5

### DIFF
--- a/lib/egaugex.ex
+++ b/lib/egaugex.ex
@@ -119,6 +119,7 @@ defmodule Egaugex do
           |> List.flatten
         end)
         |> List.zip
+        |> Enum.map(fn x -> Tuple.to_list(x) end)
 
       data = Enum.zip(registers, values) |> Enum.into(%{})
       %{attributes: atts, data: data}

--- a/lib/egaugex.ex
+++ b/lib/egaugex.ex
@@ -1,5 +1,5 @@
 defmodule Egaugex do
-  # require Logger
+  require Logger
   require HTTPoison
 
   @moduledoc """
@@ -106,15 +106,23 @@ defmodule Egaugex do
           end
       end) |> Enum.into(%{})
 
-      # get first register name
-      {_, _, [register_name]} = Floki.find(values, "cname") |> List.first
+      # create list of registers
+      registers = values
+        |> Floki.find("cname")
+        |> Enum.map(fn {_, _, register} -> register end)
+        |> List.flatten
 
       # get values for first register name
-      values = Floki.find(values, "r") |> Enum.map(fn r ->
-          {_, _, [value]} = Floki.find(r, "c") |> List.first
-          value
-      end)
-      %{attributes: atts, register: register_name, values: values}
+      values = Floki.find(values, "r")
+        |> Enum.map(fn r ->
+          Floki.find(r, "c")
+          |> Enum.map(fn {_, _, value} -> value end)
+          |> List.flatten
+        end)
+      |> List.zip
+
+      data = Enum.zip(registers, values) |> Enum.into(%{})
+      %{attributes: atts, data: data}
     end
 
     @doc """

--- a/lib/egaugex.ex
+++ b/lib/egaugex.ex
@@ -1,5 +1,4 @@
 defmodule Egaugex do
-  require Logger
   require HTTPoison
 
   @moduledoc """

--- a/lib/egaugex.ex
+++ b/lib/egaugex.ex
@@ -118,7 +118,7 @@ defmodule Egaugex do
           |> Enum.map(fn {_, _, value} -> value end)
           |> List.flatten
         end)
-      |> List.zip
+        |> List.zip
 
       data = Enum.zip(registers, values) |> Enum.into(%{})
       %{attributes: atts, data: data}

--- a/test/egaugex_test.exs
+++ b/test/egaugex_test.exs
@@ -35,8 +35,8 @@ defmodule EgaugexTest do
     """
     result = Egaugex.Parser.parse_egauge_data(data)
     assert result == %{attributes: %{"columns" => "4", "epoch" => "1422034920", "time_delta" => "1", "time_stamp" => "1462215365"},
-      data: %{"CT1" => {"-8380988951", "-8380987261"}, "CT2" => {"-9517686129", "-9517684585"}, "CT3" => {"-8703109347", "-8703107716"},
-      "Grid" => {"-26601784427", "-26601779562"}}}
+      data: %{"CT1" => ["-8380988951", "-8380987261"], "CT2" => ["-9517686129", "-9517684585"], "CT3" => ["-8703109347", "-8703107716"],
+      "Grid" => ["-26601784427", "-26601779562"]}}
   end
 
   test "hex_to_int converts hex to integer correctly" do

--- a/test/egaugex_test.exs
+++ b/test/egaugex_test.exs
@@ -34,7 +34,9 @@ defmodule EgaugexTest do
     </group>
     """
     result = Egaugex.Parser.parse_egauge_data(data)
-    assert result == %{attributes: %{"columns" => "4", "epoch" => "1422034920", "time_delta" => "1", "time_stamp" => "1462215365"}, register: "Grid", values: ["-26601784427", "-26601779562"]}
+    assert result == %{attributes: %{"columns" => "4", "epoch" => "1422034920", "time_delta" => "1", "time_stamp" => "1462215365"},
+      data: %{"CT1" => {"-8380988951", "-8380987261"}, "CT2" => {"-9517686129", "-9517684585"}, "CT3" => {"-8703109347", "-8703107716"},
+      "Grid" => {"-26601784427", "-26601779562"}}}
   end
 
   test "hex_to_int converts hex to integer correctly" do


### PR DESCRIPTION
@Brightergy-Bruce @Brightergy-JonathanHockman can you please review this change? It basically includes all the registers formatted to be consumed in places like insertion as jsonb. This closes #5 
